### PR TITLE
Hide unmerged courses from sidebar and course list

### DIFF
--- a/whiteboard/content.js
+++ b/whiteboard/content.js
@@ -1,6 +1,6 @@
 (async () => {
     const urlPrefix = "https://elearning.utdallas.edu";
-    var options = ['enabled', 'showGroupGrades', 'showNotifications', 'showGroupSidebar', 'loadStories'];
+    var options = ['enabled', 'showGroupGrades', 'showNotifications', 'showGroupSidebar', 'showUnmerged', 'loadStories'];
 
     // logic to determine if we should activate whiteboard on this page
     chrome.storage.local.get(options, async function (result) {

--- a/whiteboard/js/home.js
+++ b/whiteboard/js/home.js
@@ -359,10 +359,17 @@ export default async function home(template) {
             return a.course.name > b.course.name ? 1 : a.course.name < b.course.name ? -1 : 0;
         });
 
+        console.log(courseArr.map(x => x.course.name))
+
+        const mergedCourses = [];
         // add the "real" classes first
         for (var course of courseArr) {
             // NOTE: this could break if the 2212 pattern changes!
             if (!course.course.courseId.startsWith('2212-')) continue;
+
+            if (mergedCourses.some(val => course.course.name.indexOf(val) != -1)) 
+                continue;
+
             var newElement = createElementFromHTML(
                 `<div class="zoomDiv course demo-updates mdl-card mdl-shadow--2dp mdl-cell mdl-cell--12-col mdl-cell--12-col-tablet mdl-cell--6-col-desktop">
                     <div class="mdl-card__title mdl-card--expand mdl-color--cyan-100">
@@ -376,6 +383,13 @@ export default async function home(template) {
             );
             // newElement.querySelector(".courseContent").textContent = "Course content goes here"; // what to put here?
             document.querySelector(".courseAll").appendChild(newElement);
+
+            // mark if this is a merged course. This logic blocks the unmerged courses from being seen
+            if (course.course.name.startsWith('(MERGED) ')) {
+                const matches = course.course.name.match(/[A-Z]{2,4} \d{4}\.\w{3}/g)
+                if (matches)
+                    matches.forEach(m => mergedCourses.push(m));
+            }
         }
         // add the other stuff at the bottom
         // TODO: work on groups

--- a/whiteboard/js/home.js
+++ b/whiteboard/js/home.js
@@ -367,8 +367,10 @@ export default async function home(template) {
             // NOTE: this could break if the 2212 pattern changes!
             if (!course.course.courseId.startsWith('2212-')) continue;
 
-            if (mergedCourses.some(val => course.course.name.indexOf(val) != -1)) 
-                continue;
+            if (
+                !options['showUnmerged'] && 
+                mergedCourses.some(val => course.course.name.indexOf(val) != -1)
+            )   continue;
 
             var newElement = createElementFromHTML(
                 `<div class="zoomDiv course demo-updates mdl-card mdl-shadow--2dp mdl-cell mdl-cell--12-col mdl-cell--12-col-tablet mdl-cell--6-col-desktop">

--- a/whiteboard/js/utils.js
+++ b/whiteboard/js/utils.js
@@ -553,6 +553,7 @@ function fetchCourseList() {
         return new Promise(function (resolve, reject) {
             chrome.storage.local.get({ links: {} }, function (result) {
                 var courses = [];
+                let mergedCourses = [];
                 for (var c of courseArr) {
                     // NOTE: this could break if the 2212 pattern changes!
                     // TODO find better way to separate course/group
@@ -564,6 +565,8 @@ function fetchCourseList() {
                     var group = c.course.organization === true;
                     if (!(f20 || group))
                         continue;
+                    if (mergedCourses.some(val => c.course.name.indexOf(val) != -1)) 
+                        continue;
                     var newElement = {};
                     newElement.id = c.course.id;
                     newElement.href = urlPrefix + "/webapps/blackboard/content/listContent.jsp?course_id=" + c.course.id;
@@ -573,6 +576,13 @@ function fetchCourseList() {
 
                     if (!(c.course.id in courseIds)) {
                         courseIds[c.course.id] = c.course.name.split("-")[0].replace("(MERGED) ", "");
+                    }
+
+                    // mark if this is a merged course. This logic blocks the unmerged courses from being seen
+                    if (c.course.name.startsWith('(MERGED) ')) {
+                        const matches = c.course.name.match(/[A-Z]{2,4} \d{4}\.\w{3}/g)
+                        if (matches)
+                            matches.forEach(m => mergedCourses.push(m));
                     }
                 }
                 resolve(courses);

--- a/whiteboard/js/utils.js
+++ b/whiteboard/js/utils.js
@@ -565,7 +565,7 @@ function fetchCourseList() {
                     var group = c.course.organization === true;
                     if (!(f20 || group))
                         continue;
-                    if (mergedCourses.some(val => c.course.name.indexOf(val) != -1)) 
+                    if (!options['showUnmerged'] && mergedCourses.some(val => c.course.name.indexOf(val) != -1)) 
                         continue;
                     var newElement = {};
                     newElement.id = c.course.id;

--- a/whiteboard/options.js
+++ b/whiteboard/options.js
@@ -1,7 +1,7 @@
 const urlPrefix = "https://elearning.utdallas.edu/webapps";
 
-var options = ['enabled', 'showGroupGrades', 'showNotifications', 'showGroupSidebar', 'loadStories'];
-var defaults = [true, false, false, false, false];
+var options = ['enabled', 'showGroupGrades', 'showNotifications', 'showGroupSidebar', 'showUnmerged', 'loadStories'];
+var defaults = [true, false, false, false, true, false];
 
 // set checkbox
 chrome.storage.local.get(options, function (result) {

--- a/whiteboard/popup.html
+++ b/whiteboard/popup.html
@@ -91,9 +91,17 @@
             <span class="slider round"></span>
         </label>
         <br />
+        
         Show Groups on Sidebar:
         <label class="switch">
             <input type="checkbox" id="showGroupSidebar" />
+            <span class="slider round"></span>
+        </label>
+        <br />
+
+        Show Unmerged Courses:
+        <label class="switch">
+            <input type="checkbox" id="showUnmerged" />
             <span class="slider round"></span>
         </label>
     <hr />


### PR DESCRIPTION
Done in an attempt to prevent confusion between merged courses and unmerged courses.
Behavior: Hides unmerged courses if a "merged" version is available. 

Todo:
- [x] Move this into a settings switch, in case some prof actually uses the unmerged courses. 